### PR TITLE
Fix error logging in country service

### DIFF
--- a/src/services/countries.js
+++ b/src/services/countries.js
@@ -7,7 +7,7 @@ export async function getAllCountriesAPI() {
     const data = await response.json();
     return data;
   } catch (error) {
-    console.erro(error);
+    console.error(error);
     throw new Error("Error fetching countries");
   }
 }
@@ -21,7 +21,7 @@ export async function getCountriesByRegionAPI(region) {
     const data = await response.json();
     return data;
   } catch (error) {
-    console.erro(error);
+    console.error(error);
     throw new Error("Error fetching countries");
   }
 }


### PR DESCRIPTION
## Summary
- fix typo in error logging for API calls

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68408d4d1a6c832bb160662626c37a21